### PR TITLE
add other music functions: harmonicsByFret, harmonicsByRatio, harmoni…

### DIFF
--- a/ly/words.py
+++ b/ly/words.py
@@ -228,8 +228,11 @@ lilypond_music_commands = (
     'graceSettings',
     'grobdescriptions', # since 2.23
     'harmonic',
-    'harmonicByFret', # since 2.23
-    'harmonicByRatio', # since 2.23
+    'harmonicByFret', # since 2.20
+    'harmonicByRatio', # since 2.20
+    'harmonicNote',
+    'harmonicsOff',
+    'harmonicsOn',
     'hideNotes',
     'hideStaffSwitch',
     'huge',
@@ -392,7 +395,7 @@ lilypond_music_commands = (
     'single', # since 2.18
     'skip',
     'skipTypesetting',
-    'slashedGrace', # 2.23
+    'slashedGrace', # since 2.20
     'slurDashed',
     'slurDotted',
     'slurDown',


### PR DESCRIPTION
…cNote, harmonicsOn

I often use \harmonicByFret function.. While checking the [music functions appendix](http://www.lilypond.org/doc/v2.19/Documentation/notation/available-music-functions) I found also some other words missing.
