### PR TITLE
add raw string identifier for docstring in ly.musicxml.lymus2musxml

### DIFF
--- a/ly/musicxml/lymus2musxml.py
+++ b/ly/musicxml/lymus2musxml.py
@@ -102,7 +102,7 @@ class ParseSource():
         self.parse_document(doc)
 
     def parse_document(self, ly_doc, relative_first_pitch_absolute=False):
-        """Parse the LilyPond source specified as a ly.document document.
+        r"""Parse the LilyPond source specified as a ly.document document.
         
         If relative_first_pitch_absolute is set to True, the first pitch in a
         \relative expression without startpitch is considered to be absolute


### PR DESCRIPTION
There's a \relative command in the docstring, but there's no raw string identifier.
In the [musicxml document](http://python-ly.readthedocs.io/en/latest/ly.musicxml.html) is it resolved with error