### PR TITLE
Never use mup as format guess

### DIFF
--- a/ly/lex/_mode.py
+++ b/ly/lex/_mode.py
@@ -28,12 +28,12 @@ There are two items in this module:
    This maps a mode name to a function returning the base parser class for
    that mode.  (This way the corresponding module only needs to be imported
    when the mode is really needed.)
-   
+
 2. the guessMode function.
 
    This tries to guess the type of the given text and returns a mode name.
-   
-   
+
+
 You can easily add more modes in separate modules and mention them here,
 
 Don't use this module directly!  modes and guessMode are imported in the main
@@ -48,42 +48,42 @@ __all__ = ['modes', 'guessMode']
 
 def _modes():
     """Returns a dictionary mapping a mode name to a function.
-    
+
     The function should return the initial Parser instance for that mode.
-    
+
     """
-    
+
     def lilypond():
         from . import lilypond
         return lilypond.ParseGlobal
-    
+
     def scheme():
         from . import scheme
         return scheme.ParseScheme
-        
+
     def docbook():
         from . import docbook
         return docbook.ParseDocBook
-        
+
     def latex():
         from . import latex
         return latex.ParseLaTeX
-        
+
     def texinfo():
         from . import texinfo
         return texinfo.ParseTexinfo
-        
+
     def html():
         from . import html
         return html.ParseHTML
-        
+
     def mup():
         from . import mup
         return mup.ParseMup
-    
+
     # more modes can be added here
     return locals()
-    
+
 
 # dictionary mapping mode name to a function returning initial parser instance
 # for that mode. Can also be used to test the existence of a mode
@@ -93,9 +93,9 @@ del _modes
 
 def guessMode(text):
     """Tries to guess the type of the input text, using a quite fast heuristic.
-    
+
     Returns one of the strings also present as key in the modes dictionary.
-    
+
     """
     text = text.lstrip()
     if text.startswith(('%', '\\')):
@@ -115,11 +115,6 @@ def guessMode(text):
         return "scheme"
     if text.startswith('@'):
         return "texinfo"
-    if text.startswith('//'):
-        return "mup"
-    s = text.split(None, 1)
-    if s and s[0] in ('include', 'score', 'music'):
-        return "mup"
     return "lilypond"
 
 
@@ -134,4 +129,3 @@ extensions = {
     'docbook':  '.docbook',
     'mup':      '.mup',
 }
-


### PR DESCRIPTION
python-ly's support for MUP is rather anecdotal compared to its main function (LilyPond format library), and the guessing rule was recognizing some LilyPond files as MUP.

Fixes frescobaldi/frescobaldi#1635