### PR TITLE
Add more robust logic to find the last Bar in a ScorePart

### DIFF
--- a/ly/musicxml/xml_objs.py
+++ b/ly/musicxml/xml_objs.py
@@ -96,8 +96,8 @@ class IterateXmlObjs():
 
     def iterate_part(self, part):
         """The part is iterated."""
-        if part.barlist:
-            last_bar = part.barlist[-1]
+        last_bar = part.last_bar()
+        if last_bar:
             last_bar_objs = last_bar.obj_list
             part.set_first_bar(self.divisions)
             self.musxml.create_part(part.name, part.abbr, part.midi)
@@ -457,6 +457,12 @@ class ScorePart(ScoreSection):
                     section_bar.obj_list.append(glob_barattr)
             section.barlist.append(section_bar)
         return section
+
+    def last_bar(self):
+        """Returns the last Bar object in the score, or None if the score is empty."""
+        for obj in reversed(self.barlist):
+            if isinstance(obj, Bar):
+                return obj
 
 
 class Bar():


### PR DESCRIPTION
This avoids an `AttributeError` if the last object in a `ScorePart`'s `barlist` is not a `Bar`. For example, `\addlyrics` blocks are represented by simple Python `list`s rather than `Bar` objects.

Fixes #69.