### PR TITLE
some tests for ly.reformat

### DIFF
--- a/tests/test_reformat.py
+++ b/tests/test_reformat.py
@@ -1,0 +1,33 @@
+import pytest
+
+import ly.document
+import ly.indent
+import ly.reformat
+
+
+def _expect_unchanged(input):
+    return (input, input)
+
+
+@pytest.mark.parametrize('given,expected', [
+    ('', ''),
+    (' ', ''),
+    ("  \\version \"2.24.0\"  ", "\\version \"2.24.0\""),
+
+    ("\\relative { c''4 c \n c c }",
+     "\\relative {\n  c''4 c\n  c c\n}"),
+
+    _expect_unchanged("\\version \"2.24.0\" \\score { \\new Staff \\relative { c''4 c c c } }"),
+    ("\\score { \n \\new Staff \\relative { c''4 c c c } }",
+     "\\score {\n  \\new Staff \\relative { c''4 c c c }\n}"),
+    ("\\score { \\new Staff \\relative { c''4 c \n c c } }",
+     "\\score {\n  \\new Staff \\relative {\n    c''4 c\n    c c\n  }\n}"),
+])
+def test_reformat(given, expected):
+    indenter = ly.indent.Indenter()
+
+    doc = ly.document.Document(given)
+    cursor = ly.document.Cursor(doc)
+    ly.reformat.reformat(cursor, indenter)
+
+    assert cursor.text() == expected


### PR DESCRIPTION
As a follow-up to the (not-so-)recent [conversation on the mailing list](https://groups.google.com/g/frescobaldi/c/ha1--IbzThI) I think it's useful to have an executable description of what the `ly reformat` command does.

Internally it calls `ly.reformat.reformat()`, behavior of which depends on presence/absence of newlines in individual code blocks. The discussed example

```lilypond
\version "2.24.4" \score { \new Staff \relative { c''4 c c c } }
```

contains no newlines => no reformatting takes place. If some newline is inserted, result of the reformatting differs based on where the newline is/are placed.